### PR TITLE
handle not found errors

### DIFF
--- a/lib/paypoint/blue/error.rb
+++ b/lib/paypoint/blue/error.rb
@@ -36,6 +36,9 @@ module PayPoint
       # types of errors
       class Client < Error; end
 
+      # Specific error class for non existing sessions
+      class NotFound < Error; end
+
       # Specific error class for errors with a +'V'+ outcome code
       class Validation < Error; end
 

--- a/lib/paypoint/blue/raise_errors.rb
+++ b/lib/paypoint/blue/raise_errors.rb
@@ -28,12 +28,22 @@ module PayPoint
           else
             raise Error::Client, response_values(env)
           end
-        elsif env.status >= 400
+        elsif not_found?(env)
+          raise Error::NotFound, response_values(env)
+        elsif client_error?(env)
           raise Error::Client, response_values(env)
         end
       end
 
       private
+
+      def not_found?(env)
+        env.status == 404 && env.body[:reason_code] == "A400"
+      end
+
+      def client_error?(env)
+        env.status >= 400
+      end
 
       def fetch_outcome(env)
         env.body.is_a?(Hash) && env.body[:outcome]
@@ -46,8 +56,6 @@ module PayPoint
           body:    env.body
         }
       end
-
     end
-
   end
 end

--- a/test/fixtures/transaction_not_found.json
+++ b/test/fixtures/transaction_not_found.json
@@ -1,0 +1,7 @@
+HTTP/1.1 404 NOT FOUND
+Server: Apache-Coyote/1.1
+Set-Cookie: rememberMe=deleteMe; Path=/acceptor; Max-Age=0; Expires=Mon, 11-May-2015 08:54:50 GMT
+Content-Type: application/json;charset=UTF-8
+Date: Tue, 12 May 2015 08:54:50 GMT
+
+{"status":"FAILED","reasonCode":"A400","reasonMessage":"No such transaction"}

--- a/test/test_paypoint_blue_api.rb
+++ b/test/test_paypoint_blue_api.rb
@@ -129,6 +129,20 @@ class TestPayPointBlueAPI < Minitest::Test
     assert_equal ['SUCCESS', 'FAILED'], response.map { |txn| txn.transaction.status }
   end
 
+  def test_transaction_not_found
+    merchant_ref = 'xyz-42'
+    stub_api_get("transactions/1234/byRef?merchantRef=#{merchant_ref}").
+      to_return(fixture("transaction_not_found.json"))
+
+    error = assert_raises(PayPoint::Blue::Error::NotFound) do
+      @blue.transactions_by_ref(merchant_ref)
+    end
+    # NOTE: The transaction not found error response doesn't include
+    # an `outcome` field, therefore the message will be generic
+    assert_equal 'the server responded with status 404', error.message
+    assert_nil error.code
+  end
+
   def test_refund_payment
     txn_id = '10044236139'
     stub_api_post("transactions/1234/#{txn_id}/refund").

--- a/test/test_paypoint_blue_api.rb
+++ b/test/test_paypoint_blue_api.rb
@@ -129,20 +129,6 @@ class TestPayPointBlueAPI < Minitest::Test
     assert_equal ['SUCCESS', 'FAILED'], response.map { |txn| txn.transaction.status }
   end
 
-  def test_transaction_not_found
-    merchant_ref = 'xyz-42'
-    stub_api_get("transactions/1234/byRef?merchantRef=#{merchant_ref}").
-      to_return(fixture("transaction_not_found.json"))
-
-    error = assert_raises(PayPoint::Blue::Error::NotFound) do
-      @blue.transactions_by_ref(merchant_ref)
-    end
-    # NOTE: The transaction not found error response doesn't include
-    # an `outcome` field, therefore the message will be generic
-    assert_equal 'the server responded with status 404', error.message
-    assert_nil error.code
-  end
-
   def test_refund_payment
     txn_id = '10044236139'
     stub_api_post("transactions/1234/#{txn_id}/refund").

--- a/test/test_paypoint_blue_hosted.rb
+++ b/test/test_paypoint_blue_hosted.rb
@@ -77,6 +77,20 @@ class TestPayPointBlueHosted < Minitest::Test
     assert_equal "SUCCESS", response.status
   end
 
+  def test_transaction_not_found
+    merchant_ref = 'xyz-42'
+    stub_api_get("transactions/1234/byRef?merchantRef=#{merchant_ref}").
+      to_return(fixture("transaction_not_found.json"))
+
+    error = assert_raises(PayPoint::Blue::Error::NotFound) do
+      @blue.transactions_by_ref(merchant_ref)
+    end
+    # NOTE: The transaction not found error response doesn't include
+    # an `outcome` field, therefore the message will be generic
+    assert_equal 'the server responded with status 404', error.message
+    assert_nil error.code
+  end
+
   private
 
   def payment_payload


### PR DESCRIPTION
Although we discussed moving toward treating not found errors as not being an "exceptional" case, currently the api library has a strong set of exceptions for pretty much everything apart from the golden path.
This PR embraces that philosophy, and provides a specific exception for the case where a transaction is not recognised by PayPoint (which usually means the user cancelled the payment process while on the hosted payment page)
