### PR TITLE
[CP-2518] Change the api mite url

### DIFF
--- a/lib/paypoint/blue/api.rb
+++ b/lib/paypoint/blue/api.rb
@@ -3,7 +3,7 @@ require "paypoint/blue/base"
 # Client class for the API product.
 class PayPoint::Blue::API < PayPoint::Blue::Base
   ENDPOINTS = {
-    test: "https://api.mite.pay360.com:2443/acceptor/rest",
+    test: "https://api.mite.pay360.com/acceptor/rest",
     live: "https://api.pay360.com/acceptor/rest",
   }.freeze
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -7,7 +7,7 @@ require "webmock/minitest"
 include PayPoint::Blue::Utils
 
 def api_endpoint
-  "https://api.mite.pay360.com:2443/acceptor/rest/"
+  "https://api.mite.pay360.com/acceptor/rest/"
 end
 
 def hosted_endpoint

--- a/test/test_faraday_runscope.rb
+++ b/test/test_faraday_runscope.rb
@@ -11,10 +11,7 @@ class TestFaradayRunscope < Minitest::Test
 
   def test_runscope_integration
     stub_request(:get, endpoint("/transactions/ping"))
-      .with(
-        headers:    { "Runscope-Request-Port" => "2443" },
-        basic_auth: %w(ABC secret),
-      )
+      .with(basic_auth: %w(ABC secret))
       .to_return(fixture("ping_runscope"))
     response = @blue.ping
     assert_equal true, response
@@ -24,7 +21,6 @@ class TestFaradayRunscope < Minitest::Test
     transformed_url = "http://with--dash-example-com-bucket.runscope.net/callback/preauth"
     stub_request(:post, endpoint("/transactions/123/payment"))
       .with(
-        headers:    { "Runscope-Request-Port" => "2443" },
         body:       camelcase_and_symbolize_keys(payment_payload(callback_url: transformed_url)),
         basic_auth: %w(ABC secret),
       )


### PR DESCRIPTION
There were some changes so the payment doesn’t work on the dev
environment. I asked Pay360 and give back the right url. So it looks
like the port don’t needed anymore.